### PR TITLE
DD-1202: find CMDI files in a dataset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-            <version>0.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/nl/knaw/dans/verifydataset/api/CmdiResponse.java
+++ b/src/main/java/nl/knaw/dans/verifydataset/api/CmdiResponse.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.verifydataset.api;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class CmdiResponse {
+    private String status;
+    private List<String> cmdiFiles= new LinkedList<>();
+    private List<String> errorMessages = new LinkedList<>();
+
+    public CmdiResponse() {
+    }
+
+    public void setErrorMessages(List<String> errorMessages) {
+        this.errorMessages = errorMessages;
+    }
+
+    public List<String> getErrorMessages() {
+        return errorMessages;
+    }
+
+    public List<String> getCmdiFiles() {
+        return cmdiFiles;
+    }
+
+    public void setCmdiFiles(List<String> cmdiFiles) {
+        this.cmdiFiles = cmdiFiles;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/nl/knaw/dans/verifydataset/api/CmdiResponse.java
+++ b/src/main/java/nl/knaw/dans/verifydataset/api/CmdiResponse.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.verifydataset.api;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 public class CmdiResponse {
     private String status;
@@ -48,5 +49,29 @@ public class CmdiResponse {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        CmdiResponse that = (CmdiResponse) o;
+        return status.equals(that.status) && cmdiFiles.equals(that.cmdiFiles) && errorMessages.equals(that.errorMessages);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(status, cmdiFiles, errorMessages);
+    }
+
+    @Override
+    public String toString() {
+        return "CmdiResponse{" +
+            "status='" + status + '\'' +
+            ", cmdiFiles=" + cmdiFiles +
+            ", errorMessages=" + errorMessages +
+            '}';
     }
 }

--- a/src/main/java/nl/knaw/dans/verifydataset/api/RuleResponse.java
+++ b/src/main/java/nl/knaw/dans/verifydataset/api/RuleResponse.java
@@ -18,13 +18,13 @@ package nl.knaw.dans.verifydataset.api;
 import java.util.List;
 import java.util.Map;
 
-public class VerifyResponse {
+public class RuleResponse {
     private Map<String, List<String>> errors;
 
-    public VerifyResponse() {
+    public RuleResponse() {
     }
 
-    public VerifyResponse(Map<String, List<String>> errors) {
+    public RuleResponse(Map<String, List<String>> errors) {
         this.errors = errors;
     }
 

--- a/src/main/java/nl/knaw/dans/verifydataset/api/VerifyResponse.java
+++ b/src/main/java/nl/knaw/dans/verifydataset/api/VerifyResponse.java
@@ -15,24 +15,24 @@
  */
 package nl.knaw.dans.verifydataset.api;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class VerifyResponse {
-    private HashMap<String, List<String>> errors;
+    private Map<String, List<String>> errors;
 
     public VerifyResponse() {
     }
 
-    public VerifyResponse(HashMap<String, List<String>> errors) {
+    public VerifyResponse(Map<String, List<String>> errors) {
         this.errors = errors;
     }
 
-    public void setErrors(HashMap<String, List<String>> errors) {
+    public void setErrors(Map<String, List<String>> errors) {
         this.errors = errors;
     }
 
-    public HashMap<String, List<String>> getErrors() {
+    public Map<String, List<String>> getErrors() {
         return errors;
     }
 }

--- a/src/main/java/nl/knaw/dans/verifydataset/core/CmdiChecker.java
+++ b/src/main/java/nl/knaw/dans/verifydataset/core/CmdiChecker.java
@@ -69,7 +69,7 @@ public class CmdiChecker {
                         }
                     }
                 }
-                catch (DataverseException | IOException | ParserConfigurationException | SAXException e) {
+                catch (Exception e) {
                     dcmiResponse.getErrorMessages().add(msgIntro(fileId, name) + e);
                 }
             }

--- a/src/main/java/nl/knaw/dans/verifydataset/core/CmdiChecker.java
+++ b/src/main/java/nl/knaw/dans/verifydataset/core/CmdiChecker.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.verifydataset.core;
+
+import nl.knaw.dans.lib.dataverse.DataverseClient;
+import nl.knaw.dans.lib.dataverse.DataverseException;
+import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CmdiChecker {
+    private static final Logger log = LoggerFactory.getLogger(CmdiChecker.class);
+    private static final String cmdiSchema = "http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/1.1/profiles/clarin.eu:cr1:p_1493735943953/xsd";
+    private final DataverseClient dataverse;
+
+    public CmdiChecker(DataverseClient dataverse) {
+        this.dataverse = dataverse;
+    }
+
+    public List<String> find(String pid) throws IOException, DataverseException {
+        return dataverse
+            .dataset(pid).getLatestVersion().getData().getLatestVersion()
+            .getFiles().stream()
+            .filter(this::isCMDI)
+            .map(this::fileName)
+            .collect(Collectors.toList());
+    }
+
+    private String fileName(FileMeta f) {
+        return f.getDirectoryLabel() + "/" + f.getLabel();
+    }
+
+    private boolean isCMDI(FileMeta f) {
+        String contentType = f.getDataFile().getContentType();
+        int fileId = f.getDataFile().getId();
+        String name = fileName(f);
+        log.debug(String.format("checking %d %s", fileId, name));
+        if (!f.getLabel().toLowerCase().endsWith(".xml")) {
+            return false;
+        }
+        if (!contentType.toLowerCase().endsWith("xml")) {
+            log.error(String.format("not expected content type [%s] for %s", contentType, name));
+            return false;
+        }
+        try {
+            log.debug(String.format("requesting %d %s", fileId, name));
+            var response = dataverse
+                .basicFileAccess(fileId)
+                .getFile();
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != Response.Status.OK.getStatusCode()) {
+                log.error(String.format("could not read %d %s, status code:", fileId, name), statusCode);
+                return false;
+            }
+            log.debug(String.format("reading %d %s", fileId, name));
+            try (var is = response.getEntity().getContent()) {
+                // TODO validate with schema
+                return new String(is.readAllBytes()).toLowerCase().contains("cmdi");
+            }
+        }
+        catch (DataverseException | IOException e) {
+            log.error(String.format("Exception while reading %d %s", fileId, name), e);
+        }
+        return false;
+    }
+}

--- a/src/main/java/nl/knaw/dans/verifydataset/core/DataverseClientWrapper.java
+++ b/src/main/java/nl/knaw/dans/verifydataset/core/DataverseClientWrapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.verifydataset.core;
 
 import nl.knaw.dans.lib.dataverse.DataverseClient;

--- a/src/main/java/nl/knaw/dans/verifydataset/core/DataverseClientWrapper.java
+++ b/src/main/java/nl/knaw/dans/verifydataset/core/DataverseClientWrapper.java
@@ -1,0 +1,27 @@
+package nl.knaw.dans.verifydataset.core;
+
+import nl.knaw.dans.lib.dataverse.DataverseClient;
+import nl.knaw.dans.lib.dataverse.DataverseException;
+import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
+import org.apache.http.HttpResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+public class DataverseClientWrapper {
+    private final DataverseClient dataverseClient;
+
+    public DataverseClientWrapper(DataverseClient dataverseClient) {
+        this.dataverseClient = dataverseClient;
+    }
+
+    protected List<FileMeta> getFiles(String pid) throws IOException, DataverseException {
+        return dataverseClient
+            .dataset(pid).getLatestVersion().getData().getLatestVersion()
+            .getFiles();
+    }
+
+    protected HttpResponse getFile(int fileId) throws DataverseException, IOException {
+        return dataverseClient.basicFileAccess(fileId).getFile();
+    }
+}

--- a/src/main/java/nl/knaw/dans/verifydataset/resources/VerifyResource.java
+++ b/src/main/java/nl/knaw/dans/verifydataset/resources/VerifyResource.java
@@ -20,6 +20,7 @@ import nl.knaw.dans.lib.dataverse.DataverseException;
 import nl.knaw.dans.verifydataset.api.VerifyRequest;
 import nl.knaw.dans.verifydataset.api.RuleResponse;
 import nl.knaw.dans.verifydataset.core.CmdiChecker;
+import nl.knaw.dans.verifydataset.core.DataverseClientWrapper;
 import nl.knaw.dans.verifydataset.core.config.VerifyDatasetConfig;
 import nl.knaw.dans.verifydataset.core.rule.MetadataRule;
 import org.apache.commons.lang3.StringUtils;
@@ -49,7 +50,7 @@ public class VerifyResource {
 
     public VerifyResource(DataverseClient dataverse, VerifyDatasetConfig config) {
         this.dataverse = dataverse;
-        cmdiChecker = new CmdiChecker(dataverse);
+        cmdiChecker = new CmdiChecker(new DataverseClientWrapper(dataverse));
         rules = MetadataRule.configureRules(config);
     }
 

--- a/src/main/java/nl/knaw/dans/verifydataset/resources/VerifyResource.java
+++ b/src/main/java/nl/knaw/dans/verifydataset/resources/VerifyResource.java
@@ -63,13 +63,13 @@ public class VerifyResource {
         try {
             log.info("Looking for CMDI file(s) " + req);
             var files = cmdiChecker.find(req.getDatasetPid());
-            return Response.ok(new VerifyResponse(Map.of("is CMDI file", files))).build();
-        }
-        catch (IOException e) {
-            throw new InternalServerErrorException(e);
+            return Response.ok(files).build();
         }
         catch (DataverseException e) {
             return responseFromDataverseException(e);
+        }
+        catch (Exception e) {
+            throw new InternalServerErrorException(e);
         }
     }
 

--- a/src/main/java/nl/knaw/dans/verifydataset/resources/VerifyResource.java
+++ b/src/main/java/nl/knaw/dans/verifydataset/resources/VerifyResource.java
@@ -18,7 +18,7 @@ package nl.knaw.dans.verifydataset.resources;
 import nl.knaw.dans.lib.dataverse.DataverseClient;
 import nl.knaw.dans.lib.dataverse.DataverseException;
 import nl.knaw.dans.verifydataset.api.VerifyRequest;
-import nl.knaw.dans.verifydataset.api.VerifyResponse;
+import nl.knaw.dans.verifydataset.api.RuleResponse;
 import nl.knaw.dans.verifydataset.core.CmdiChecker;
 import nl.knaw.dans.verifydataset.core.config.VerifyDatasetConfig;
 import nl.knaw.dans.verifydataset.core.rule.MetadataRule;
@@ -88,7 +88,7 @@ public class VerifyResource {
             HashMap<String, List<String>> messages = new HashMap<>();
             rules.forEach((name, rule) -> messages.put(name, rule.verify(blocks)));
             // ok->accepted when we change to asynchronous
-            return Response.ok(new VerifyResponse(messages)).build();
+            return Response.ok(new RuleResponse(messages)).build();
         }
         catch (IOException e) {
             throw new InternalServerErrorException(e);

--- a/src/test/java/nl/knaw/dans/verifydataset/core/CmdiCheckerTest.java
+++ b/src/test/java/nl/knaw/dans/verifydataset/core/CmdiCheckerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.verifydataset.core;
 
 import nl.knaw.dans.lib.dataverse.DataverseException;

--- a/src/test/java/nl/knaw/dans/verifydataset/core/CmdiCheckerTest.java
+++ b/src/test/java/nl/knaw/dans/verifydataset/core/CmdiCheckerTest.java
@@ -1,0 +1,129 @@
+package nl.knaw.dans.verifydataset.core;
+
+import nl.knaw.dans.lib.dataverse.DataverseException;
+import nl.knaw.dans.lib.dataverse.model.file.DataFile;
+import nl.knaw.dans.lib.dataverse.model.file.FileMeta;
+import nl.knaw.dans.verifydataset.api.CmdiResponse;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CmdiCheckerTest {
+    private final DataverseClientWrapper dataverse = Mockito.mock(DataverseClientWrapper.class);
+
+    @BeforeEach
+    void setup() {
+        Mockito.reset(dataverse);
+    }
+
+    @Test
+    void notFoundException() throws IOException, DataverseException {
+        Mockito.doThrow(new DataverseException(404, "not found", null))
+            .when(dataverse).getFiles("");
+
+        assertThrows(DataverseException.class, () -> new CmdiChecker(dataverse).find(""));
+    }
+
+    @Test
+    void no() throws IOException, DataverseException {
+        var fm = new FileMeta();
+        DataFile df = new DataFile();
+        fm.setDataFile(df);
+        fm.setLabel("nothing.txt");
+        df.setContentType("text");
+        df.setId(1);
+        Mockito.doReturn(List.of(fm)).when(dataverse).getFiles("");
+
+        CmdiResponse expected = new CmdiResponse();
+        expected.setStatus("no");
+
+        CmdiResponse actualResponse = new CmdiChecker(dataverse).find("");
+        assertEquals(expected, actualResponse);
+    }
+
+    @Test
+    void unknownNotFound() throws IOException, DataverseException {
+        var fm = new FileMeta();
+        DataFile df = new DataFile();
+        fm.setDataFile(df);
+        fm.setLabel("nothing.cmdi");
+        df.setContentType("text");
+        df.setId(1);
+        HttpResponse httpResponse = Mockito.mock(HttpResponse.class);
+        BasicStatusLine statusLine = new BasicStatusLine(new HttpVersion(0, 0), 404, "not found");
+        Mockito.doReturn(statusLine).when(httpResponse).getStatusLine();
+        Mockito.doReturn(List.of(fm)).when(dataverse).getFiles("");
+        Mockito.doReturn(httpResponse).when(dataverse).getFile(1);
+
+        CmdiResponse expected = new CmdiResponse();
+        expected.setStatus("unknown");
+        // as if nothing.cmdi was deleted after getting the dataset metadata with list of files
+        expected.getErrorMessages().add("fileID=1 nothing.cmdi CAUSED not found");
+
+        CmdiResponse actualResponse = new CmdiChecker(dataverse).find("");
+        assertEquals(expected, actualResponse);
+    }
+    @Test
+
+    void yes() throws IOException, DataverseException {
+        var fm = new FileMeta();
+        DataFile df = new DataFile();
+        fm.setDataFile(df);
+        fm.setLabel("something.cmdi");
+        fm.setDirectoryLabel("something");
+        df.setContentType("text");
+        df.setId(1);
+        HttpResponse httpResponse = Mockito.mock(HttpResponse.class);
+        BasicStatusLine statusLine = new BasicStatusLine(new HttpVersion(0, 0), 200, "ok");
+        String s = "<CMD CMDVersion=\"1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+            + "     xsi:schemaLocation=\"http://www.clarin.eu/cmd/ http://catalog.clarin.eu/ds/ComponentRegistry/rest/registry/profiles/clarin.eu:cr1:p_1369752611610/xsd\" xmlns=\"http://www.clarin.eu/cmd/\"></CMD>\n";
+        InputStreamEntity entity = new InputStreamEntity(new ByteArrayInputStream(s.getBytes()));
+        Mockito.doReturn(statusLine).when(httpResponse).getStatusLine();
+        Mockito.doReturn(entity).when(httpResponse).getEntity();
+        Mockito.doReturn(List.of(fm)).when(dataverse).getFiles("");
+        Mockito.doReturn(httpResponse).when(dataverse).getFile(1);
+
+        CmdiResponse expected = new CmdiResponse();
+        expected.setStatus("yes");
+        expected.getCmdiFiles().add("something/something.cmdi");
+
+        CmdiResponse actualResponse = new CmdiChecker(dataverse).find("");
+        assertEquals(expected, actualResponse);
+    }
+
+    @Test
+    void empty() throws IOException, DataverseException {
+        var fm = new FileMeta();
+        DataFile df = new DataFile();
+        fm.setDataFile(df);
+        fm.setLabel("something.cmdi");
+        fm.setDirectoryLabel("something");
+        df.setContentType("text");
+        df.setId(1);
+        HttpResponse httpResponse = Mockito.mock(HttpResponse.class);
+        BasicStatusLine statusLine = new BasicStatusLine(new HttpVersion(0, 0), 200, "ok");
+        InputStreamEntity entity = new InputStreamEntity(new ByteArrayInputStream("".getBytes()));
+        Mockito.doReturn(statusLine).when(httpResponse).getStatusLine();
+        Mockito.doReturn(entity).when(httpResponse).getEntity();
+        Mockito.doReturn(List.of(fm)).when(dataverse).getFiles("");
+        Mockito.doReturn(httpResponse).when(dataverse).getFile(1);
+
+        CmdiResponse expected = new CmdiResponse();
+        expected.setStatus("unknown");
+        expected.getErrorMessages().add("fileID=1 something/something.cmdi CAUSED org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 1; Premature end of file.");
+
+        CmdiResponse actualResponse = new CmdiChecker(dataverse).find("");
+        assertEquals(expected, actualResponse);
+    }
+}

--- a/src/test/java/nl/knaw/dans/verifydataset/core/rule/AuthorNameFormatOkTest.java
+++ b/src/test/java/nl/knaw/dans/verifydataset/core/rule/AuthorNameFormatOkTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.verifydataset.rule;
+package nl.knaw.dans.verifydataset.core.rule;
 
 import io.dropwizard.configuration.ConfigurationException;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;

--- a/src/test/java/nl/knaw/dans/verifydataset/core/rule/CoordinatesWithinBoundsTest.java
+++ b/src/test/java/nl/knaw/dans/verifydataset/core/rule/CoordinatesWithinBoundsTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.verifydataset.rule;
+package nl.knaw.dans.verifydataset.core.rule;
 
 import io.dropwizard.configuration.ConfigurationException;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;

--- a/src/test/java/nl/knaw/dans/verifydataset/core/rule/IdentifierHasValidMod11Test.java
+++ b/src/test/java/nl/knaw/dans/verifydataset/core/rule/IdentifierHasValidMod11Test.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.verifydataset.rule;
+package nl.knaw.dans.verifydataset.core.rule;
 
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;
 import nl.knaw.dans.verifydataset.core.rule.IdentifierHasValidMod11;

--- a/src/test/java/nl/knaw/dans/verifydataset/resources/VerifyResourceTest.java
+++ b/src/test/java/nl/knaw/dans/verifydataset/resources/VerifyResourceTest.java
@@ -39,6 +39,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.List;
 
@@ -49,8 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class VerifyResourceTest {
 
-    DataverseClient dataverse = Mockito.mock(DataverseClient.class);
-    public final ResourceExtension EXT = ResourceExtension.builder()
+    private DataverseClient dataverse = Mockito.mock(DataverseClient.class);
+    private final ResourceExtension EXT = ResourceExtension.builder()
         .addResource(new VerifyResource(dataverse, loadDistConfig()))
         .build();
 
@@ -87,13 +88,11 @@ public class VerifyResourceTest {
                 };
             }
         };
-        // neither of the following mocks work, using null instead
-        // (org.mockito.exceptions.misusing.WrongTypeOfReturnValue)
-        // HttpResponse response1 = Mockito.mock(HttpResponse.class);
-        // HttpResponse<String> response2 = (HttpResponse<String>) Mockito.mock(HttpResponse.class);
-        // HttpResponse<String> response3 = new HttpResponse<String>(){...};
+        // Mockito does not like the generic method
+        HttpResponse<String> response = null;
+
         BasicFileAccessApi fileAccessApi = Mockito.mock(BasicFileAccessApi.class);
-        Mockito.doReturn(null).when(fileAccessApi).getFile();
+        Mockito.doReturn(response).when(fileAccessApi).getFile();
         Mockito.doReturn(fileAccessApi).when(dataverse).basicFileAccess(999);
         Mockito.doReturn(datasetApi).when(dataverse).dataset(Mockito.any(String.class));
 


### PR DESCRIPTION
Fixes DD-1201: find CMDI files in a dataset

# Description of changes

a new request type

# How to test

* Upload an xml and cmdi file from this [list](https://drive.google.com/file/d/1XMesAR5cNkyYme95gTrDTfhskHmUas--/view)  to a dataset in `https://dar.dans.knaw.nl `
* deployed on `dev_archaeology-2022-10-08.box` you can use the specified DOI:

      curl -w '\n' -X POST -d '{ "datasetPid": "doi:10.5072/DAR/RGICM5" }' --header 'Content-Type: application/json' http://dar.dans.knaw.nl:20345/verify/check-cmdi

# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans


[DD-1201]: https://drivenbydata.atlassian.net/browse/DD-1201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ